### PR TITLE
use port declared in configuration to establish connection

### DIFF
--- a/src/pf_driver/src/pf/pf_interface.cpp
+++ b/src/pf_driver/src/pf/pf_interface.cpp
@@ -56,7 +56,7 @@ bool PFInterface::init(std::shared_ptr<HandleInfo> info, std::shared_ptr<ScanCon
 
   if (info->handle_type == HandleInfo::HANDLE_TYPE_UDP)
   {
-    transport_ = std::make_unique<UDPTransport>(info->hostname);
+    transport_ = std::make_unique<UDPTransport>(info->hostname, info->port);
     if (!transport_->connect())
     {
       RCLCPP_ERROR(node_->get_logger(), "Unable to establish UDP connection");

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -189,6 +189,14 @@ void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& p
   {
     query["packet_type"] = config_->packet_type;
   }
+  if (!port.empty())
+  {
+    query["port"] = port;
+  }
+  else
+  {
+    query["port"] = info_->port;
+  }
   auto resp = get_request("request_handle_tcp", { "handle", "port" }, query);
 
   info_->handle = resp["handle"];

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -193,7 +193,7 @@ void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& p
   {
     query["port"] = port;
   }
-  else
+  else if (info_->port.compare("0") != 0)
   {
     query["port"] = info_->port;
   }

--- a/src/pf_driver/src/ros/ros_main.cpp
+++ b/src/pf_driver/src/ros/ros_main.cpp
@@ -14,6 +14,7 @@ int main(int argc, char* argv[])
 
   std::string device, transport_str, scanner_ip, port, topic, frame_id, packet_type;
   int samples_per_scan, start_angle, max_num_points_scan, watchdogtimeout, num_layers;
+  port = "0";
   num_layers = 0;
   bool watchdog, apply_correction = 0;
 


### PR DESCRIPTION
r2300_params.yaml:
```
...
    port: 6464
...
```

ROS log:
```
ubuntu@ubuntu:~/ros2/nov23_01$ ros2 launch pf_driver r2300.launch.py 
[INFO] [launch]: All log files can be found below /home/ubuntu/.ros/log/2023-11-24-08-59-54-200570-ubuntu-6341
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [ros_main-1]: process started with pid [6344]
[INFO] [robot_state_publisher-2]: process started with pid [6346]
[INFO] [rviz2-3]: process started with pid [6348]
[robot_state_publisher-2] [INFO] [1700812794.368360280] [robot_state_publisher]: got segment scanner_link
[robot_state_publisher-2] [INFO] [1700812794.368444388] [robot_state_publisher]: got segment world
[ros_main-1] [INFO] [1700812794.369042311] [ros_main]: device name: 
[ros_main-1] [INFO] [1700812794.369120178] [ros_main]: transport_str: udp
[ros_main-1] [INFO] [1700812794.369142950] [ros_main]: scanner_ip: 169.254.0.101
[ros_main-1] [INFO] [1700812794.369152068] [ros_main]: port: 6464
[ros_main-1] [INFO] [1700812794.369161044] [ros_main]: start_angle: 0
[ros_main-1] [INFO] [1700812794.369172436] [ros_main]: max_num_points_scan: 250
[ros_main-1] [INFO] [1700812794.369180872] [ros_main]: watchdogtimeout: 60000
[ros_main-1] [INFO] [1700812794.369189177] [ros_main]: watchdog: 0
[ros_main-1] [INFO] [1700812794.369197453] [ros_main]: num_layers: 4
[ros_main-1] [INFO] [1700812794.369207572] [ros_main]: topic: /cloud
[ros_main-1] [INFO] [1700812794.369216288] [ros_main]: frame_id: scanner_link
[ros_main-1] [INFO] [1700812794.369224564] [ros_main]: packet_type: C1
[ros_main-1] [INFO] [1700812794.369233350] [ros_main]: apply_correction: 1
[ros_main-1] [INFO] [1700812794.369292261] [ros_main]: start_angle: 0
[ros_main-1] qos_overrides./tf_static.publisher.history keep_last
[ros_main-1] protocol error: 120 invalid handle or no handle provided
[ros_main-1] qos_overrides./tf_static.publisher.depth 1
[ros_main-1] protocol error: 120 invalid handle or no handle provided
[ros_main-1] qos_overrides./tf_static.publisher.reliability reliable
[ros_main-1] protocol error: 120 invalid handle or no handle provided
[ros_main-1] [INFO] [1700812794.443567446] [ros_main]: Device found: R2300
[ros_main-1] [INFO] [1700812794.463762583] [ros_main]: Device state changed to Initialized
[ros_main-1] [INFO] [1700812794.466939082] [ros_main]: Device state changed to Running
[ros_main-1] Failed to find match for field 'x'.
[ros_main-1] Failed to find match for field 'y'.
[ros_main-1] Failed to find match for field 'z'.
[ros_main-1] Failed to find match for field 'intensity'.
[rviz2-3] [INFO] [1700812794.572847506] [rviz2]: Stereo is NOT SUPPORTED
[rviz2-3] [INFO] [1700812794.572959246] [rviz2]: OpenGl version: 4.6 (GLSL 4.6)
[rviz2-3] [INFO] [1700812794.584926943] [rviz2]: Stereo is NOT SUPPORTED
```
TCP dump (port = 34057):
```
ubuntu@ubuntu:~/ros2/nov23_01$ sudo tcpdump -i any host 169.254.0.101 and udp
09:00:00.198707 enx2c16dbae0a96 In  IP 169.254.0.101.49153 > ubuntu.local.34057: UDP, length 1084
```