### PR TITLE
Remove merge artifacts from license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-=======
-
->>>>>>> porting-ros2
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -190,11 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-<<<<<<< HEAD
-   Copyright [yyyy] [name of copyright owner]
-=======
    Copyright 2022 Pepperl+Fuchs SE
->>>>>>> porting-ros2
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
There were some <<<< and >>>> markers from some bad merge. Removed it to clear the License file.