### PR TITLE
Enable clean exit from main loop and termination of driver process with SIGINT

### DIFF
--- a/src/pf_driver/src/pf/pipeline.cpp
+++ b/src/pf_driver/src/pf/pipeline.cpp
@@ -89,9 +89,10 @@ void Pipeline::run_writer()
   running_ = false;
 
   // notify main thread about network failure
+  if (net_mtx_->try_lock())
   {
-    std::lock_guard<std::mutex> lock(*net_mtx_);
     net_fail_ = true;
+    net_mtx_->unlock();
   }
   net_cv_->notify_one();
 }


### PR DESCRIPTION
The changes in fix/terminate-on-sigint allow to exit from main loop with SIGINT. This might not be the only issue with the main loop and state handling but at least it fixes #19 