### PR TITLE
Output Inf/NaN as appropriate if measurement result was invalid

### DIFF
--- a/src/pf_driver/src/ros/pf_data_publisher.cpp
+++ b/src/pf_driver/src/ros/pf_data_publisher.cpp
@@ -101,8 +101,8 @@ void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_incl
     }
 
     msg->ranges.resize(packet.header.num_points_scan);
-    if (!packet.amplitude.empty())
-      msg->intensities.resize(packet.header.num_points_scan);
+    msg->intensities.resize(packet.amplitude.empty() ? 0 : packet.header.num_points_scan);
+
     d_queue_.push_back(msg);
   }
   msg = d_queue_.back();


### PR DESCRIPTION
The changes to `pf_data_publisher.cpp` from this branch shall improve the values where measurement yielded no result, e.g. due to blinding, no echo, or other reasons as reported by the sensor with an error code instead of amplitude value. This fixes #18 

While at it, it also improves the `intensities[]` output by emptying the vector elements if the sensor didn't deliver any (R2000 packet type A transports distance values only), as demanded by the LaserScan specification ("If your device does not provide intensities, please leave the array empty.").