### PR TITLE
Let sensor start scan output with packet_type and watchdog only optionally explicitly set by driver

### DIFF
--- a/src/pf_driver/include/pf_driver/pf/pfsdp_base.h
+++ b/src/pf_driver/include/pf_driver/pf/pfsdp_base.h
@@ -100,15 +100,13 @@ public:
 
   std::string get_parameter_str(const std::string& param);
 
-  void request_handle_tcp(const std::string& port = "", const std::string& packet_type = "");
+  void request_handle_tcp();
 
-  virtual void request_handle_udp(const std::string& packet_type = "");
+  virtual void request_handle_udp();
 
   bool release_handle(const std::string& handle);
 
   virtual void get_scanoutput_config(const std::string& handle);
-
-  bool set_scanoutput_config(const std::string& handle, const ScanConfig& config);
 
   bool update_scanoutput_config();
 

--- a/src/pf_driver/include/pf_driver/pf/scan_config.h
+++ b/src/pf_driver/include/pf_driver/pf/scan_config.h
@@ -5,22 +5,11 @@
 struct ScanConfig
 {
   bool watchdog = false;
-  bool watchdog_set = false;
-
   uint watchdogtimeout = 0;
-  bool watchdogtimeout_set = false;
-
   std::string packet_type = "";
-  bool packet_type_set = false;
-
   int start_angle = 0;
-  bool start_angle_set = false;
-
   uint max_num_points_scan = 0;
-  bool max_num_points_scan_set = false;
-
   uint skip_scans = 0;
-  bool skip_scans_set = false;
 
   // void print()
   // {

--- a/src/pf_driver/include/pf_driver/pf/scan_config.h
+++ b/src/pf_driver/include/pf_driver/pf/scan_config.h
@@ -5,11 +5,22 @@
 struct ScanConfig
 {
   bool watchdog = false;
+  bool watchdog_set = false;
+
   uint watchdogtimeout = 0;
+  bool watchdogtimeout_set = false;
+
   std::string packet_type = "";
+  bool packet_type_set = false;
+
   int start_angle = 0;
+  bool start_angle_set = false;
+
   uint max_num_points_scan = 0;
+  bool max_num_points_scan_set = false;
+
   uint skip_scans = 0;
+  bool skip_scans_set = false;
 
   // void print()
   // {

--- a/src/pf_driver/src/pf/pf_interface.cpp
+++ b/src/pf_driver/src/pf/pf_interface.cpp
@@ -112,8 +112,14 @@ bool PFInterface::init(std::shared_ptr<HandleInfo> info, std::shared_ptr<ScanCon
   }
 
   prev_handle_ = info_->handle;
-  protocol_interface_->setup_parameters_callback();
+
+  /* Configure sensor from ScanConfig (only user-set options) */
   protocol_interface_->update_scanoutput_config();
+
+  /* Update our ScanConfig from sensor (all options) */
+  protocol_interface_->get_scanoutput_config(info_->handle);
+
+  protocol_interface_->setup_parameters_callback();
   protocol_interface_->set_connection_failure_cb(std::bind(&PFInterface::connection_failure_cb, this));
   change_state(PFState::INIT);
   return true;

--- a/src/pf_driver/src/pf/pf_interface.cpp
+++ b/src/pf_driver/src/pf/pf_interface.cpp
@@ -158,11 +158,14 @@ bool PFInterface::start_transmission(std::shared_ptr<std::mutex> net_mtx,
     return false;
 
   protocol_interface_->start_scanoutput();
-  // start watchdog timer is watchdog is true in config AND if the device is not R2000
-  // since watchdog for R2300 is always off
-  if (config_->watchdog && protocol_interface_->get_product().find("R2000") != std::string::npos)
+  if (config_->watchdog)
   {
-    start_watchdog_timer(config_->watchdogtimeout / 1000.0);
+    double timeout_s = config_->watchdogtimeout / 1000.0;
+    if (timeout_s < 0.1)
+    {
+      timeout_s = 0.1;
+    }
+    start_watchdog_timer(timeout_s);
   }
   change_state(PFState::RUNNING);
   return true;

--- a/src/pf_driver/src/pf/pf_interface.cpp
+++ b/src/pf_driver/src/pf/pf_interface.cpp
@@ -113,7 +113,7 @@ bool PFInterface::init(std::shared_ptr<HandleInfo> info, std::shared_ptr<ScanCon
 
   prev_handle_ = info_->handle;
 
-  /* Configure sensor from ScanConfig (only user-set options) */
+  /* Configure sensor from ScanConfig (only explicitly set options) */
   protocol_interface_->update_scanoutput_config();
 
   /* Update our ScanConfig from sensor (all options) */

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -269,9 +269,6 @@ void PFSDPBase::request_handle_tcp()
 
   info_->handle = resp["handle"];
   info_->port = resp["port"];
-
-  /* Update ScanConfig */
-  get_scanoutput_config(info_->handle);
 }
 
 void PFSDPBase::request_handle_udp()
@@ -283,9 +280,6 @@ void PFSDPBase::request_handle_udp()
   }
   auto resp = get_request("request_handle_udp", { "handle", "port" }, query);
   info_->handle = resp["handle"];
-
-  /* Update ScanConfig */
-  get_scanoutput_config(info_->handle);
 }
 
 void PFSDPBase::get_scanoutput_config(const std::string& handle)
@@ -304,30 +298,31 @@ void PFSDPBase::get_scanoutput_config(const std::string& handle)
 
 bool PFSDPBase::update_scanoutput_config()
 {
-  param_map_type query;
+  param_map_type query = { KV("handle", info_->handle) };
+
   if (config_->start_angle_set)
   {
-    query["start_angle"] = config_->start_angle;
+    query.insert(KV("start_angle", config_->start_angle));
   }
   if (config_->packet_type_set)
   {
-    query["packet_type"] = config_->packet_type;
+    query.insert(KV("packet_type", config_->packet_type));
   }
   if (config_->max_num_points_scan_set)
   {
-    query["max_num_points_scan"] = config_->max_num_points_scan;
+    query.insert(KV("max_num_points_scan", config_->max_num_points_scan));
   }
   if (config_->skip_scans_set)
   {
-    query["skip_scans"] = config_->skip_scans;
+    query.insert(KV("skip_scans", config_->skip_scans));
   }
   if (config_->watchdogtimeout_set)
   {
-    query["watchdogtimeout"] = config_->watchdogtimeout;
+    query.insert(KV("watchdogtimeout", config_->watchdogtimeout));
   }
   if (config_->watchdog_set)
   {
-    query["watchdog"] = config_->watchdog ? "on" : "off";
+    query.insert(KV("watchdogtimeout", config_->watchdog ? "on" : "off"));
   }
 
   auto resp = get_request("set_scanoutput_config", { "" }, query);

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -257,7 +257,7 @@ std::string PFSDPBase::get_parameter_str(const std::string& param)
 void PFSDPBase::request_handle_tcp()
 {
   param_map_type query;
-  if (config_->packet_type_set)
+  if (!config_->packet_type.empty())
   {
     query["packet_type"] = config_->packet_type;
   }
@@ -274,7 +274,7 @@ void PFSDPBase::request_handle_tcp()
 void PFSDPBase::request_handle_udp()
 {
   param_map_type query = { KV("address", info_->endpoint), KV("port", info_->port) };
-  if (config_->packet_type_set)
+  if (!config_->packet_type.empty())
   {
     query["packet_type"] = config_->packet_type;
   }
@@ -300,29 +300,21 @@ bool PFSDPBase::update_scanoutput_config()
 {
   param_map_type query = { KV("handle", info_->handle) };
 
-  if (config_->start_angle_set)
-  {
-    query.insert(KV("start_angle", config_->start_angle));
-  }
-  if (config_->packet_type_set)
+  query.insert(KV("start_angle", config_->start_angle));
+  if (!config_->packet_type.empty())
   {
     query.insert(KV("packet_type", config_->packet_type));
   }
-  if (config_->max_num_points_scan_set)
-  {
-    query.insert(KV("max_num_points_scan", config_->max_num_points_scan));
-  }
-  if (config_->skip_scans_set)
-  {
-    query.insert(KV("skip_scans", config_->skip_scans));
-  }
-  if (config_->watchdogtimeout_set)
+  query.insert(KV("max_num_points_scan", config_->max_num_points_scan));
+  query.insert(KV("skip_scans", config_->skip_scans));
+  if (config_->watchdogtimeout != 0)
   {
     query.insert(KV("watchdogtimeout", config_->watchdogtimeout));
   }
-  if (config_->watchdog_set)
+  if (config_->watchdog == false)
   {
-    query.insert(KV("watchdogtimeout", config_->watchdog ? "on" : "off"));
+    /* Force watchdog off. Otherwise (if watchdog==true), use scanner default */
+    query.insert(KV("watchdog", "off"));
   }
 
   auto resp = get_request("set_scanoutput_config", { "" }, query);
@@ -414,27 +406,22 @@ bool PFSDPBase::reconfig_callback_impl(const std::vector<rclcpp::Parameter>& par
     else if (parameter.get_name() == "watchdog")
     {
       config_->watchdog = parameter.as_bool();
-      config_->watchdog_set = true;
     }
     else if (parameter.get_name() == "watchdogtimeout")
     {
       config_->watchdogtimeout = parameter.as_int();
-      config_->watchdogtimeout_set = true;
     }
     else if (parameter.get_name() == "start_angle")
     {
       config_->start_angle = parameter.as_int();
-      config_->start_angle_set = true;
     }
     else if (parameter.get_name() == "max_num_points_scan")
     {
       config_->max_num_points_scan = parameter.as_int();
-      config_->max_num_points_scan_set = true;
     }
     else if (parameter.get_name() == "skip_scans")
     {
       config_->skip_scans = parameter.as_int();
-      config_->skip_scans_set = true;
     }
   }
 

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -259,7 +259,7 @@ void PFSDPBase::request_handle_tcp(int port)
   param_vector_type query;
   if (!config_->packet_type.empty())
   {
-    query.push_back(KV("packet_type", packet_type));
+    query.push_back(KV("packet_type", config_->packet_type));
   }
   if (port != 0)
   {
@@ -271,7 +271,7 @@ void PFSDPBase::request_handle_tcp(int port)
   info_->actual_port = parser_utils::to_long(resp["port"]);
 }
 
-void PFSDPBase::request_handle_udp(const std::string& packet_type)
+void PFSDPBase::request_handle_udp()
 {
   param_vector_type query = { KV("address", info_->endpoint), KV("port", info_->actual_port) };
   if (!config_->packet_type.empty())

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -254,22 +254,14 @@ std::string PFSDPBase::get_parameter_str(const std::string& param)
   return resp[param];
 }
 
-void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& packet_type)
+void PFSDPBase::request_handle_tcp()
 {
   param_map_type query;
-  if (!packet_type.empty())
-  {
-    query["packet_type"] = packet_type;
-  }
-  else
+  if (config_->packet_type_set)
   {
     query["packet_type"] = config_->packet_type;
   }
-  if (!port.empty())
-  {
-    query["port"] = port;
-  }
-  else if (info_->port.compare("0") != 0)
+  if (info_->port.compare("0") != 0)
   {
     query["port"] = info_->port;
   }
@@ -278,22 +270,22 @@ void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& p
   info_->handle = resp["handle"];
   info_->port = resp["port"];
 
-  // TODO: port and pkt_type should be updated in config_
+  /* Update ScanConfig */
+  get_scanoutput_config(info_->handle);
 }
 
-void PFSDPBase::request_handle_udp(const std::string& packet_type)
+void PFSDPBase::request_handle_udp()
 {
   param_map_type query = { KV("address", info_->endpoint), KV("port", info_->port) };
-  if (!packet_type.empty())
-  {
-    query["packet_type"] = packet_type;
-  }
-  else
+  if (config_->packet_type_set)
   {
     query["packet_type"] = config_->packet_type;
   }
   auto resp = get_request("request_handle_udp", { "handle", "port" }, query);
   info_->handle = resp["handle"];
+
+  /* Update ScanConfig */
+  get_scanoutput_config(info_->handle);
 }
 
 void PFSDPBase::get_scanoutput_config(const std::string& handle)
@@ -310,36 +302,35 @@ void PFSDPBase::get_scanoutput_config(const std::string& handle)
   config_->max_num_points_scan = parser_utils::to_long(resp["max_num_points_scan"]);
 }
 
-bool PFSDPBase::set_scanoutput_config(const std::string& handle, const ScanConfig& config)
-{
-  param_map_type query = { KV("handle", handle),
-                           KV("start_angle", config.start_angle),
-                           KV("packet_type", config.packet_type),
-                           KV("max_num_points_scan", config.max_num_points_scan),
-                           KV("watchdogtimeout", config.watchdogtimeout),
-                           KV("skip_scans", config.skip_scans),
-                           KV("watchdog", config.watchdog ? "on" : "off") };
-  auto resp = get_request("set_scanoutput_config", { "" }, query);
-
-  // update global config_
-  get_scanoutput_config(handle);
-  get_scan_parameters();
-  return true;
-}
-
 bool PFSDPBase::update_scanoutput_config()
 {
-  param_map_type query = { KV("handle", info_->handle),
-                           KV("start_angle", config_->start_angle),
-                           KV("packet_type", config_->packet_type),
-                           KV("max_num_points_scan", config_->max_num_points_scan),
-                           KV("watchdogtimeout", config_->watchdogtimeout),
-                           KV("skip_scans", config_->skip_scans),
-                           KV("watchdog", config_->watchdog ? "on" : "off") };
-  auto resp = get_request("set_scanoutput_config", { "" }, query);
+  param_map_type query;
+  if (config_->start_angle_set)
+  {
+    query["start_angle"] = config_->start_angle;
+  }
+  if (config_->packet_type_set)
+  {
+    query["packet_type"] = config_->packet_type;
+  }
+  if (config_->max_num_points_scan_set)
+  {
+    query["max_num_points_scan"] = config_->max_num_points_scan;
+  }
+  if (config_->skip_scans_set)
+  {
+    query["skip_scans"] = config_->skip_scans;
+  }
+  if (config_->watchdogtimeout_set)
+  {
+    query["watchdogtimeout"] = config_->watchdogtimeout;
+  }
+  if (config_->watchdog_set)
+  {
+    query["watchdog"] = config_->watchdog ? "on" : "off";
+  }
 
-  // recalculate scan params
-  get_scan_parameters();
+  auto resp = get_request("set_scanoutput_config", { "" }, query);
   return true;
 }
 
@@ -428,22 +419,27 @@ bool PFSDPBase::reconfig_callback_impl(const std::vector<rclcpp::Parameter>& par
     else if (parameter.get_name() == "watchdog")
     {
       config_->watchdog = parameter.as_bool();
+      config_->watchdog_set = true;
     }
     else if (parameter.get_name() == "watchdogtimeout")
     {
       config_->watchdogtimeout = parameter.as_int();
+      config_->watchdogtimeout_set = true;
     }
     else if (parameter.get_name() == "start_angle")
     {
       config_->start_angle = parameter.as_int();
+      config_->start_angle_set = true;
     }
     else if (parameter.get_name() == "max_num_points_scan")
     {
       config_->max_num_points_scan = parameter.as_int();
+      config_->max_num_points_scan_set = true;
     }
     else if (parameter.get_name() == "skip_scans")
     {
       config_->skip_scans = parameter.as_int();
+      config_->skip_scans_set = true;
     }
   }
 

--- a/src/pf_driver/src/ros/ros_main.cpp
+++ b/src/pf_driver/src/ros/ros_main.cpp
@@ -16,6 +16,7 @@ int main(int argc, char* argv[])
   std::string device;
   std::string transport_str;
   std::string scanner_ip;
+  int port = 0; /* 0 means: automatic */
   std::string topic("/scan");
   std::string frame_id("scanner_link");
   std::string packet_type; /* empty means: use scanner default */

--- a/src/pf_driver/src/ros/ros_main.cpp
+++ b/src/pf_driver/src/ros/ros_main.cpp
@@ -14,6 +14,10 @@ int main(int argc, char* argv[])
   rclcpp::init(argc, argv);
   auto node = std::make_shared<rclcpp::Node>("pf_driver");
 
+  std::shared_ptr<ScanConfig> config = std::make_shared<ScanConfig>();
+
+  rclcpp::Parameter tmp_param;
+
   std::vector<std::string> pfsdp_init;
   std::string device, transport_str, scanner_ip, port, topic, frame_id, packet_type;
   int samples_per_scan, start_angle, max_num_points_scan, watchdogtimeout, skip_scans, num_layers;
@@ -52,31 +56,47 @@ int main(int argc, char* argv[])
 
   if (!node->has_parameter("start_angle"))
   {
-    node->declare_parameter("start_angle", start_angle);
+    node->declare_parameter("start_angle", rclcpp::PARAMETER_INTEGER);
   }
-  node->get_parameter("start_angle", start_angle);
-  RCLCPP_INFO(node->get_logger(), "start_angle: %d", start_angle);
+  if (node->get_parameter("start_angle", tmp_param))
+  {
+    config->start_angle = tmp_param.as_int();
+    config->start_angle_set = true;
+    RCLCPP_INFO(node->get_logger(), "start_angle: %d", config->start_angle);
+  }
 
   if (!node->has_parameter("max_num_points_scan"))
   {
-    node->declare_parameter("max_num_points_scan", max_num_points_scan);
+    node->declare_parameter("max_num_points_scan", rclcpp::PARAMETER_INTEGER);
   }
-  node->get_parameter("max_num_points_scan", max_num_points_scan);
-  RCLCPP_INFO(node->get_logger(), "max_num_points_scan: %d", max_num_points_scan);
+  if (node->get_parameter("max_num_points_scan", tmp_param))
+  {
+    config->max_num_points_scan = tmp_param.as_int();
+    config->max_num_points_scan_set = true;
+    RCLCPP_INFO(node->get_logger(), "max_num_points_scan: %d", config->max_num_points_scan);
+  }
 
   if (!node->has_parameter("watchdogtimeout"))
   {
-    node->declare_parameter("watchdogtimeout", watchdogtimeout);
+    node->declare_parameter("watchdogtimeout", rclcpp::PARAMETER_INTEGER);
   }
-  node->get_parameter("watchdogtimeout", watchdogtimeout);
-  RCLCPP_INFO(node->get_logger(), "watchdogtimeout: %d", watchdogtimeout);
+  if (node->get_parameter("watchdogtimeout", tmp_param))
+  {
+    config->watchdogtimeout = tmp_param.as_int();
+    config->watchdogtimeout_set = true;
+    RCLCPP_INFO(node->get_logger(), "watchdogtimeout: %d", config->watchdogtimeout);
+  }
 
   if (!node->has_parameter("watchdog"))
   {
-    node->declare_parameter("watchdog", watchdog);
+    node->declare_parameter("watchdog", rclcpp::PARAMETER_BOOL);
   }
-  node->get_parameter("watchdog", watchdog);
-  RCLCPP_INFO(node->get_logger(), "watchdog: %d", watchdog);
+  if (node->get_parameter("watchdog", tmp_param))
+  {
+    config->watchdog = tmp_param.as_bool();
+    config->watchdog_set = true;
+    RCLCPP_INFO(node->get_logger(), "watchdog: %s", config->watchdog ? "on" : "off");
+  }
 
   if (!node->has_parameter("num_layers"))
   {
@@ -101,10 +121,14 @@ int main(int argc, char* argv[])
 
   if (!node->has_parameter("packet_type"))
   {
-    node->declare_parameter("packet_type", packet_type);
+    node->declare_parameter("packet_type", rclcpp::PARAMETER_STRING);
   }
-  node->get_parameter("packet_type", packet_type);
-  RCLCPP_INFO(node->get_logger(), "packet_type: %s", packet_type.c_str());
+  if (node->get_parameter("packet_type", tmp_param))
+  {
+    config->packet_type = tmp_param.as_string();
+    config->packet_type_set = true;
+    RCLCPP_INFO(node->get_logger(), "packet_type: %s", config->packet_type.c_str());
+  }
 
   if (!node->has_parameter("apply_correction"))
   {
@@ -115,10 +139,14 @@ int main(int argc, char* argv[])
 
   if (!node->has_parameter("skip_scans"))
   {
-    node->declare_parameter("skip_scans", skip_scans);
+    node->declare_parameter("skip_scans", rclcpp::PARAMETER_INTEGER);
   }
-  node->get_parameter("skip_scans", skip_scans);
-  RCLCPP_INFO(node->get_logger(), "skip_scans: %d", skip_scans);
+  if (node->get_parameter("skip_scans", tmp_param))
+  {
+    config->skip_scans = tmp_param.as_int();
+    config->skip_scans_set = true;
+    RCLCPP_INFO(node->get_logger(), "skip_scans: %d", config->skip_scans);
+  }
 
   if (!node->has_parameter("pfsdp_init"))
   {
@@ -137,15 +165,6 @@ int main(int argc, char* argv[])
 
   info->hostname = node->get_parameter("scanner_ip").get_parameter_value().get<std::string>();
   info->port = node->get_parameter("port").get_parameter_value().get<std::string>();
-
-  std::shared_ptr<ScanConfig> config = std::make_shared<ScanConfig>();
-  config->start_angle = node->get_parameter("start_angle").get_parameter_value().get<int>();
-  config->max_num_points_scan = node->get_parameter("max_num_points_scan").get_parameter_value().get<int>();
-  config->skip_scans = node->get_parameter("skip_scans").get_parameter_value().get<int>();
-  config->packet_type = node->get_parameter("packet_type").get_parameter_value().get<std::string>();
-  config->watchdogtimeout = node->get_parameter("watchdogtimeout").get_parameter_value().get<int>();
-  config->watchdog = node->get_parameter("watchdog").get_parameter_value().get<bool>();
-  RCLCPP_INFO(node->get_logger(), "start_angle: %d", config->start_angle);
 
   std::shared_ptr<ScanParameters> params = std::make_shared<ScanParameters>();
   params->apply_correction = node->get_parameter("apply_correction").get_parameter_value().get<bool>();

--- a/src/pf_driver/src/ros/ros_main.cpp
+++ b/src/pf_driver/src/ros/ros_main.cpp
@@ -14,17 +14,22 @@ int main(int argc, char* argv[])
   rclcpp::init(argc, argv);
   auto node = std::make_shared<rclcpp::Node>("pf_driver");
 
-  std::shared_ptr<ScanConfig> config = std::make_shared<ScanConfig>();
-
-  rclcpp::Parameter tmp_param;
-
   std::vector<std::string> pfsdp_init;
-  std::string device, transport_str, scanner_ip, port, topic, frame_id, packet_type;
-  int samples_per_scan, start_angle, max_num_points_scan, watchdogtimeout, skip_scans, num_layers;
-  port = "0";
-  num_layers = 0;
-  skip_scans = 0;
-  bool watchdog, apply_correction = 0;
+  std::string device;
+  std::string transport_str;
+  std::string scanner_ip;
+  std::string port("0"); /* 0 means: automatic */
+  std::string topic("/scan");
+  std::string frame_id("scanner_link");
+  std::string packet_type; /* empty means: use scanner default */
+  int samples_per_scan = 0;
+  int start_angle = -1800000;
+  int max_num_points_scan = 0;
+  int watchdogtimeout = 0; /* "0" means: use scanner default */
+  int skip_scans = 0;
+  int num_layers = 1;
+  bool watchdog = true; /* "true" means: use scanner default */
+  bool apply_correction = false;
 
   if (!node->has_parameter("device"))
   {
@@ -56,47 +61,31 @@ int main(int argc, char* argv[])
 
   if (!node->has_parameter("start_angle"))
   {
-    node->declare_parameter("start_angle", rclcpp::PARAMETER_INTEGER);
+    node->declare_parameter("start_angle", start_angle);
   }
-  if (node->get_parameter("start_angle", tmp_param))
-  {
-    config->start_angle = tmp_param.as_int();
-    config->start_angle_set = true;
-    RCLCPP_INFO(node->get_logger(), "start_angle: %d", config->start_angle);
-  }
+  node->get_parameter("start_angle", start_angle);
+  RCLCPP_INFO(node->get_logger(), "start_angle: %d", start_angle);
 
   if (!node->has_parameter("max_num_points_scan"))
   {
-    node->declare_parameter("max_num_points_scan", rclcpp::PARAMETER_INTEGER);
+    node->declare_parameter("max_num_points_scan", max_num_points_scan);
   }
-  if (node->get_parameter("max_num_points_scan", tmp_param))
-  {
-    config->max_num_points_scan = tmp_param.as_int();
-    config->max_num_points_scan_set = true;
-    RCLCPP_INFO(node->get_logger(), "max_num_points_scan: %d", config->max_num_points_scan);
-  }
+  node->get_parameter("max_num_points_scan", max_num_points_scan);
+  RCLCPP_INFO(node->get_logger(), "max_num_points_scan: %d", max_num_points_scan);
 
   if (!node->has_parameter("watchdogtimeout"))
   {
-    node->declare_parameter("watchdogtimeout", rclcpp::PARAMETER_INTEGER);
+    node->declare_parameter("watchdogtimeout", watchdogtimeout);
   }
-  if (node->get_parameter("watchdogtimeout", tmp_param))
-  {
-    config->watchdogtimeout = tmp_param.as_int();
-    config->watchdogtimeout_set = true;
-    RCLCPP_INFO(node->get_logger(), "watchdogtimeout: %d", config->watchdogtimeout);
-  }
+  node->get_parameter("watchdogtimeout", watchdogtimeout);
+  RCLCPP_INFO(node->get_logger(), "watchdogtimeout: %d", watchdogtimeout);
 
   if (!node->has_parameter("watchdog"))
   {
-    node->declare_parameter("watchdog", rclcpp::PARAMETER_BOOL);
+    node->declare_parameter("watchdog", watchdog);
   }
-  if (node->get_parameter("watchdog", tmp_param))
-  {
-    config->watchdog = tmp_param.as_bool();
-    config->watchdog_set = true;
-    RCLCPP_INFO(node->get_logger(), "watchdog: %s", config->watchdog ? "on" : "off");
-  }
+  node->get_parameter("watchdog", watchdog);
+  RCLCPP_INFO(node->get_logger(), "watchdog: %d", watchdog);
 
   if (!node->has_parameter("num_layers"))
   {
@@ -121,14 +110,10 @@ int main(int argc, char* argv[])
 
   if (!node->has_parameter("packet_type"))
   {
-    node->declare_parameter("packet_type", rclcpp::PARAMETER_STRING);
+    node->declare_parameter("packet_type", packet_type);
   }
-  if (node->get_parameter("packet_type", tmp_param))
-  {
-    config->packet_type = tmp_param.as_string();
-    config->packet_type_set = true;
-    RCLCPP_INFO(node->get_logger(), "packet_type: %s", config->packet_type.c_str());
-  }
+  node->get_parameter("packet_type", packet_type);
+  RCLCPP_INFO(node->get_logger(), "packet_type: %s", packet_type.c_str());
 
   if (!node->has_parameter("apply_correction"))
   {
@@ -139,14 +124,10 @@ int main(int argc, char* argv[])
 
   if (!node->has_parameter("skip_scans"))
   {
-    node->declare_parameter("skip_scans", rclcpp::PARAMETER_INTEGER);
+    node->declare_parameter("skip_scans", skip_scans);
   }
-  if (node->get_parameter("skip_scans", tmp_param))
-  {
-    config->skip_scans = tmp_param.as_int();
-    config->skip_scans_set = true;
-    RCLCPP_INFO(node->get_logger(), "skip_scans: %d", config->skip_scans);
-  }
+  node->get_parameter("skip_scans", skip_scans);
+  RCLCPP_INFO(node->get_logger(), "skip_scans: %d", skip_scans);
 
   if (!node->has_parameter("pfsdp_init"))
   {
@@ -165,6 +146,15 @@ int main(int argc, char* argv[])
 
   info->hostname = node->get_parameter("scanner_ip").get_parameter_value().get<std::string>();
   info->port = node->get_parameter("port").get_parameter_value().get<std::string>();
+
+  std::shared_ptr<ScanConfig> config = std::make_shared<ScanConfig>();
+  config->start_angle = node->get_parameter("start_angle").get_parameter_value().get<int>();
+  config->max_num_points_scan = node->get_parameter("max_num_points_scan").get_parameter_value().get<int>();
+  config->skip_scans = node->get_parameter("skip_scans").get_parameter_value().get<int>();
+  config->packet_type = node->get_parameter("packet_type").get_parameter_value().get<std::string>();
+  config->watchdogtimeout = node->get_parameter("watchdogtimeout").get_parameter_value().get<int>();
+  config->watchdog = node->get_parameter("watchdog").get_parameter_value().get<bool>();
+  RCLCPP_INFO(node->get_logger(), "start_angle: %d", config->start_angle);
 
   std::shared_ptr<ScanParameters> params = std::make_shared<ScanParameters>();
   params->apply_correction = node->get_parameter("apply_correction").get_parameter_value().get<bool>();


### PR DESCRIPTION
These changes make the explicit setting of `packet_type`, `watchdog` and `watchdogtimeout` during scan output initialization optional. The user may choose to not specify values for these parameters in `*.yaml`, the driver will let the sensor choose and therefore does not have to know in advance about the particular values supported by the attached sensor model.

1. If user omits `packet_type`, the sensor default (`"A"` in R2000, `"C1"` in R2300) will take effect.
2. If user omits `watchdog` or specifies `watchdog: true`, the sensor default (`true` in R2000, `false` in R2300) will take effect. If  `watchdog: false` is set, the driver will enforce `watchdog="off"` during scan output initialization.

Also there are defaults set for all other driver parameters except for the `sensor_ip`; the `*.yaml` could be left almost empty. We might consider to provide an `"auto"` or `"ssdp"` default setting for {{sensor_ip}} to choose device search using SSDP, but that's not within the scope of the changes here.
