### PR TITLE
"port" parameter should be handled as integer, not string

### DIFF
--- a/src/pf_driver/config/r2000_params.yaml
+++ b/src/pf_driver/config/r2000_params.yaml
@@ -2,7 +2,7 @@ pf_r2000:
   ros__parameters:
     transport: "udp"
     scanner_ip: "10.0.10.9"
-    # port: "3000" # optional
+    # port: 3000 # optional
     device: "R2000"
     start_angle: -1800000
     max_num_points_scan: 0

--- a/src/pf_driver/config/r2300_params.yaml
+++ b/src/pf_driver/config/r2300_params.yaml
@@ -2,7 +2,7 @@ pf_r2300:
   ros__parameters:
     transport: "udp"
     scanner_ip: "169.254.235.110"
-    # port: "3000" # optional
+    # port: 3000 # optional
     start_angle: -450000
     max_num_points_scan: 0
     packet_type: "C1"

--- a/src/pf_driver/config/r2300_single_layer_params.yaml
+++ b/src/pf_driver/config/r2300_single_layer_params.yaml
@@ -2,7 +2,7 @@ pf_r2300:
   ros__parameters:
     transport: "udp"
     scanner_ip: "169.254.235.110"
-    # port: "3000" # optional
+    # port: 3000 # optional
     start_angle: -450000
     max_num_points_scan: 0
     packet_type: "C1"

--- a/src/pf_driver/include/pf_driver/communication/transport.h
+++ b/src/pf_driver/include/pf_driver/communication/transport.h
@@ -32,12 +32,12 @@ public:
   {
   }
 
-  void set_port(std::string port)
+  void set_port(int port)
   {
-    port_ = std::move(port);
+    port_ = port;
   }
 
-  std::string get_port()
+  int get_port()
   {
     return port_;
   }
@@ -65,7 +65,7 @@ public:
 protected:
   std::string address_;
   std::string host_ip_;
-  std::string port_;
+  int port_;
   bool is_connected_;
   transport_type type_;
   std::shared_ptr<boost::asio::io_service> io_service_;

--- a/src/pf_driver/include/pf_driver/communication/udp_transport.h
+++ b/src/pf_driver/include/pf_driver/communication/udp_transport.h
@@ -19,7 +19,7 @@
 class UDPTransport : public Transport
 {
 public:
-  UDPTransport(std::string address, std::string port = "0");
+  UDPTransport(std::string address, int port = 0);
 
   ~UDPTransport();
 

--- a/src/pf_driver/include/pf_driver/pf/handle_info.h
+++ b/src/pf_driver/include/pf_driver/pf/handle_info.h
@@ -9,7 +9,7 @@ struct HandleInfo
 
   int handle_type;
   std::string hostname;
-  std::string port;
+  int actual_port;
   std::string handle;
   std::string endpoint;
 };

--- a/src/pf_driver/include/pf_driver/pf/pfsdp_base.h
+++ b/src/pf_driver/include/pf_driver/pf/pfsdp_base.h
@@ -100,7 +100,7 @@ public:
 
   std::string get_parameter_str(const std::string& param);
 
-  void request_handle_tcp(const std::string& port = "", const std::string& packet_type = "");
+  void request_handle_tcp(int port = 0, const std::string& packet_type = "");
 
   virtual void request_handle_udp(const std::string& packet_type = "");
 

--- a/src/pf_driver/include/pf_driver/pf/scan_config.h
+++ b/src/pf_driver/include/pf_driver/pf/scan_config.h
@@ -10,6 +10,7 @@ struct ScanConfig
   int start_angle = 0;
   uint max_num_points_scan = 0;
   uint skip_scans = 0;
+  uint port = 0;
 
   // void print()
   // {

--- a/src/pf_driver/src/communication/tcp_transport.cpp
+++ b/src/pf_driver/src/communication/tcp_transport.cpp
@@ -26,7 +26,7 @@ bool TCPTransport::connect()
   try
   {
     tcp::resolver resolver(*io_service_);
-    tcp::resolver::query query(address_, port_);
+    tcp::resolver::query query(address_, std::to_string(port_));
     tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
     tcp::resolver::iterator end;
 

--- a/src/pf_driver/src/communication/udp_transport.cpp
+++ b/src/pf_driver/src/communication/udp_transport.cpp
@@ -9,10 +9,10 @@ using boost::asio::ip::udp;
 
 auto udp_logger = rclcpp::get_logger("transport");
 
-UDPTransport::UDPTransport(std::string address, std::string port) : Transport(address, transport_type::udp)
+UDPTransport::UDPTransport(std::string address, int port) : Transport(address, transport_type::udp)
 {
   io_service_ = std::make_shared<boost::asio::io_service>();
-  udp::endpoint local_endpoint = udp::endpoint(boost::asio::ip::address_v4::from_string("0.0.0.0"), stoi(port));
+  udp::endpoint local_endpoint = udp::endpoint(boost::asio::ip::address_v4::from_string("0.0.0.0"), port);
 
   socket_ = std::make_unique<udp::socket>(*io_service_, local_endpoint);
   timer_ = std::make_shared<boost::asio::deadline_timer>(*io_service_.get());
@@ -27,7 +27,7 @@ bool UDPTransport::connect()
 {
   udp::endpoint udp_endpoint = udp::endpoint(boost::asio::ip::address::from_string(address_), 0);
   socket_->connect(udp_endpoint);
-  port_ = std::to_string(socket_->local_endpoint().port());
+  port_ = socket_->local_endpoint().port();
   host_ip_ = socket_->local_endpoint().address().to_string();
 
   is_connected_ = true;

--- a/src/pf_driver/src/pf/pf_interface.cpp
+++ b/src/pf_driver/src/pf/pf_interface.cpp
@@ -75,7 +75,7 @@ bool PFInterface::init(std::shared_ptr<HandleInfo> info, std::shared_ptr<ScanCon
 
   if (info->handle_type == HandleInfo::HANDLE_TYPE_UDP)
   {
-    transport_ = std::make_unique<UDPTransport>(info->hostname, info->port);
+    transport_ = std::make_unique<UDPTransport>(info->hostname, config->port);
     if (!transport_->connect())
     {
       RCLCPP_ERROR(node_->get_logger(), "Unable to establish UDP connection");
@@ -83,16 +83,16 @@ bool PFInterface::init(std::shared_ptr<HandleInfo> info, std::shared_ptr<ScanCon
     }
 
     info->endpoint = transport_->get_host_ip();
-    info->port = transport_->get_port();
+    info->actual_port = transport_->get_port();
     protocol_interface_->request_handle_udp();
   }
   else if (info->handle_type == HandleInfo::HANDLE_TYPE_TCP)
   {
     transport_ = std::make_unique<TCPTransport>(info->hostname);
-    protocol_interface_->request_handle_tcp();
+    protocol_interface_->request_handle_tcp(config->port);
     // if initially port was not set, request_handle sets it
     // set the updated port in transport
-    transport_->set_port(info_->port);
+    transport_->set_port(info->actual_port);
     if (!transport_->connect())
     {
       RCLCPP_ERROR(node_->get_logger(), "Unable to establish TCP connection");

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -254,7 +254,7 @@ std::string PFSDPBase::get_parameter_str(const std::string& param)
   return resp[param];
 }
 
-void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& packet_type)
+void PFSDPBase::request_handle_tcp(int port, const std::string& packet_type)
 {
   param_map_type query;
   if (!packet_type.empty())
@@ -265,25 +265,21 @@ void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& p
   {
     query["packet_type"] = config_->packet_type;
   }
-  if (!port.empty())
+  if (port != 0)
   {
-    query["port"] = port;
-  }
-  else if (info_->port.compare("0") != 0)
-  {
-    query["port"] = info_->port;
+    query.insert(KV("port", port));
   }
   auto resp = get_request("request_handle_tcp", { "handle", "port" }, query);
 
   info_->handle = resp["handle"];
-  info_->port = resp["port"];
+  info_->actual_port = parser_utils::to_long(resp["port"]);
 
   // TODO: port and pkt_type should be updated in config_
 }
 
 void PFSDPBase::request_handle_udp(const std::string& packet_type)
 {
-  param_map_type query = { KV("address", info_->endpoint), KV("port", info_->port) };
+  param_map_type query = { KV("address", info_->endpoint), KV("port", info_->actual_port) };
   if (!packet_type.empty())
   {
     query["packet_type"] = packet_type;
@@ -417,7 +413,7 @@ bool PFSDPBase::reconfig_callback_impl(const std::vector<rclcpp::Parameter>& par
     }
     else if (parameter.get_name() == "port")
     {
-      info_->port = parameter.value_to_string();
+      config_->port = parameter.as_int();
     }
     else if (parameter.get_name() == "transport")
     {

--- a/src/pf_driver/src/ros/ros_main.cpp
+++ b/src/pf_driver/src/ros/ros_main.cpp
@@ -15,9 +15,9 @@ int main(int argc, char* argv[])
   auto node = std::make_shared<rclcpp::Node>("pf_driver");
 
   std::vector<std::string> pfsdp_init;
-  std::string device, transport_str, scanner_ip, port, topic, frame_id, packet_type;
+  std::string device, transport_str, scanner_ip, topic, frame_id, packet_type;
   int samples_per_scan, start_angle, max_num_points_scan, watchdogtimeout, skip_scans, num_layers;
-  port = "0";
+  int port = 0;
   num_layers = 0;
   skip_scans = 0;
   bool watchdog, apply_correction = 0;
@@ -48,7 +48,7 @@ int main(int argc, char* argv[])
     node->declare_parameter("port", port);
   }
   node->get_parameter("port", port);
-  RCLCPP_INFO(node->get_logger(), "port: %s", port.c_str());
+  RCLCPP_INFO(node->get_logger(), "port: %d", port);
 
   if (!node->has_parameter("start_angle"))
   {
@@ -134,11 +134,12 @@ int main(int argc, char* argv[])
   std::shared_ptr<HandleInfo> info = std::make_shared<HandleInfo>();
 
   info->handle_type = transport_str == "udp" ? HandleInfo::HANDLE_TYPE_UDP : HandleInfo::HANDLE_TYPE_TCP;
-
   info->hostname = node->get_parameter("scanner_ip").get_parameter_value().get<std::string>();
-  info->port = node->get_parameter("port").get_parameter_value().get<std::string>();
+  info->actual_port = -1;
 
   std::shared_ptr<ScanConfig> config = std::make_shared<ScanConfig>();
+
+  config->port = node->get_parameter("port").get_parameter_value().get<int>();
   config->start_angle = node->get_parameter("start_angle").get_parameter_value().get<int>();
   config->max_num_points_scan = node->get_parameter("max_num_points_scan").get_parameter_value().get<int>();
   config->skip_scans = node->get_parameter("skip_scans").get_parameter_value().get<int>();

--- a/src/pf_driver/tests/pipeline.cpp
+++ b/src/pf_driver/tests/pipeline.cpp
@@ -49,7 +49,7 @@ TEST(PFPipeline_TestSuite, testPipelineReadWrite)
   bool net_fail = false;
 
   std::unique_ptr<Transport> transport = std::make_unique<TCPTransport>("127.0.0.1");
-  transport->set_port("1234");
+  transport->set_port(1234);
 
   if (transport->connect())
   {


### PR DESCRIPTION
The changes in `fix/port-is-integer` let the driver and its components handle the TCP/UDP port as an integer, not string as before, thus avoiding irritations about the data type when preparing a `*.yaml` to configure the sensor and later on.

The change affects both the externally visible driver parameter "port" (to specify a fixed port instead of leaving the choice to the sensor or OS) and its internal representation in multiple places.-

Note that existing `*.yaml` configuration files and applications that expect the ROS parameter "port" to be a string would become incompatible with the updated driver, but I updating them should be trivial. I guess that applications where a specific port really needs to be set are not that many.