### PR TITLE
Fix/query uri encoding

### DIFF
--- a/src/pf_driver/src/pf/http_helpers/curl_resource.cpp
+++ b/src/pf_driver/src/pf/http_helpers/curl_resource.cpp
@@ -48,7 +48,7 @@ void CurlResource::get(Json::Value& json_resp)
   {
     json_resp.clear();
     /* Negate to make HTTP error code distinguishable from PFSDP error codes */
-    json_resp["error_code"] = Json::Value(-code);
+    json_resp["error_code"] = Json::Value((Json::Value::Int)-code);
     json_resp["error_text"] = Json::Value("HTTP Server Error");
   }
 }

--- a/src/pf_driver/src/pf/http_helpers/curl_resource.cpp
+++ b/src/pf_driver/src/pf/http_helpers/curl_resource.cpp
@@ -17,7 +17,7 @@ void CurlResource::append_query(const std::initializer_list<param_type>& list, b
   url_ += "?";
   for (const auto& p : list)
   {
-    url_ += p.first + "=" + p.second + "&";
+    url_ += p.first + "=" + curlpp::escape(p.second) + "&";
   }
   url_.pop_back();
 }
@@ -27,7 +27,7 @@ void CurlResource::append_query(const param_map_type& params, bool do_encoding)
   url_ += "?";
   for (const auto& p : params)
   {
-    url_ += p.first + "=" + p.second + "&";
+    url_ += p.first + "=" + curlpp::escape(p.second) + "&";
   }
   url_.pop_back();
 }

--- a/src/pf_driver/src/pf/http_helpers/curl_resource.cpp
+++ b/src/pf_driver/src/pf/http_helpers/curl_resource.cpp
@@ -48,7 +48,7 @@ void CurlResource::get(Json::Value& json_resp)
   {
     json_resp.clear();
     /* Negate to make HTTP error code distinguishable from PFSDP error codes */
-    json_resp["error_code"] = Json::Value(- code);
+    json_resp["error_code"] = Json::Value(-code);
     json_resp["error_text"] = Json::Value("HTTP Server Error");
   }
 }


### PR DESCRIPTION
When constructing GET request URIs with parameters, the parameter values should be sent URI-encoded. Otherwise they might not fully reach the sensor (try `setting user_tag=a&b`...). This branch adds proper encoding.