### PR TITLE
Fix/ensure argument order

### DIFF
--- a/src/pf_driver/include/pf_driver/pf/http_helpers/curl_resource.h
+++ b/src/pf_driver/include/pf_driver/pf/http_helpers/curl_resource.h
@@ -20,7 +20,7 @@
 #include <curlpp/Options.hpp>
 #include <json/json.h>
 
-#include "pf_driver/pf/http_helpers/param_map_type.h"
+#include "pf_driver/pf/http_helpers/param_vector_type.h"
 #include "pf_driver/pf/http_helpers/param_type.h"
 
 class CurlResource
@@ -32,7 +32,7 @@ public:
 
   void append_query(const std::initializer_list<param_type>& list, bool do_encoding = false);
 
-  void append_query(const param_map_type& params, bool do_encoding = false);
+  void append_query(const param_vector_type& params, bool do_encoding = false);
 
   void get(Json::Value& json_resp);
 

--- a/src/pf_driver/include/pf_driver/pf/http_helpers/http_interface.h
+++ b/src/pf_driver/include/pf_driver/pf/http_helpers/http_interface.h
@@ -17,7 +17,7 @@
 #include <json/json.h>
 
 #include "pf_driver/pf/http_helpers/param_type.h"
-#include "pf_driver/pf/http_helpers/param_map_type.h"
+#include "pf_driver/pf/http_helpers/param_vector_type.h"
 
 class CurlResource;
 
@@ -29,7 +29,7 @@ public:
   const Json::Value get(const std::string& command,
                         const std::initializer_list<param_type>& list = std::initializer_list<param_type>());
 
-  const Json::Value get(const std::string& command, const param_map_type& params = param_map_type());
+  const Json::Value get(const std::string& command, const param_vector_type& params = param_vector_type());
 
 private:
   const Json::Value get_(CurlResource& res);

--- a/src/pf_driver/include/pf_driver/pf/http_helpers/param_vector_type.h
+++ b/src/pf_driver/include/pf_driver/pf/http_helpers/param_vector_type.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <map>
-#include <string>
+#include <vector>
+#include "param_type.h"
 
-using param_map_type = std::map<std::string, std::string>;
+using param_vector_type = std::vector<param_type>;

--- a/src/pf_driver/include/pf_driver/pf/pfsdp_base.h
+++ b/src/pf_driver/include/pf_driver/pf/pfsdp_base.h
@@ -24,7 +24,7 @@
 
 #include "pf_driver/pf/http_helpers/http_interface.h"
 #include "pf_driver/pf/http_helpers/param_type.h"
-#include "pf_driver/pf/http_helpers/param_map_type.h"
+#include "pf_driver/pf/http_helpers/param_vector_type.h"
 #include "pf_driver/pf/handle_info.h"
 #include "pf_driver/pf/scan_config.h"
 #include "pf_driver/pf/scan_parameters.h"
@@ -45,7 +45,7 @@ private:
                                                        const std::initializer_list<param_type>& query);
   const std::map<std::string, std::string>
   get_request(const std::string& command, const std::vector<std::string>& json_keys = std::vector<std::string>(),
-              const param_map_type& query = param_map_type());
+              const param_vector_type& query = param_vector_type());
 
   bool get_request_bool(const std::string& command,
                         const std::vector<std::string>& json_keys = std::vector<std::string>(),

--- a/src/pf_driver/src/pf/http_helpers/curl_resource.cpp
+++ b/src/pf_driver/src/pf/http_helpers/curl_resource.cpp
@@ -22,7 +22,7 @@ void CurlResource::append_query(const std::initializer_list<param_type>& list, b
   url_.pop_back();
 }
 
-void CurlResource::append_query(const param_map_type& params, bool do_encoding)
+void CurlResource::append_query(const param_vector_type& params, bool do_encoding)
 {
   url_ += "?";
   for (const auto& p : params)

--- a/src/pf_driver/src/pf/http_helpers/http_interface.cpp
+++ b/src/pf_driver/src/pf/http_helpers/http_interface.cpp
@@ -15,7 +15,7 @@ const Json::Value HTTPInterface::get(const std::string& command, const std::init
   return get_(res);
 }
 
-const Json::Value HTTPInterface::get(const std::string& command, const param_map_type& params)
+const Json::Value HTTPInterface::get(const std::string& command, const param_vector_type& params)
 {
   CurlResource res(host);
   res.append_path(base_path);

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -62,12 +62,12 @@ const std::map<std::string, std::string> PFSDPBase::get_request(const std::strin
                                                                 const std::vector<std::string>& json_keys,
                                                                 const std::initializer_list<param_type>& query)
 {
-  return get_request(command, json_keys, param_map_type(query.begin(), query.end()));
+  return get_request(command, json_keys, param_vector_type(query.begin(), query.end()));
 }
 
 const std::map<std::string, std::string> PFSDPBase::get_request(const std::string& command,
                                                                 const std::vector<std::string>& json_keys,
-                                                                const param_map_type& query)
+                                                                const param_vector_type& query)
 {
   Json::Value json_resp = http_interface->get(command, query);
 
@@ -256,22 +256,22 @@ std::string PFSDPBase::get_parameter_str(const std::string& param)
 
 void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& packet_type)
 {
-  param_map_type query;
+  param_vector_type query;
   if (!packet_type.empty())
   {
-    query["packet_type"] = packet_type;
+    query.push_back(KV("packet_type", packet_type));
   }
   else
   {
-    query["packet_type"] = config_->packet_type;
+    query.push_back(KV("packet_type", config_->packet_type));
   }
   if (!port.empty())
   {
-    query["port"] = port;
+    query.push_back(KV("port", port));
   }
   else if (info_->port.compare("0") != 0)
   {
-    query["port"] = info_->port;
+    query.push_back(KV("port", info_->port));
   }
   auto resp = get_request("request_handle_tcp", { "handle", "port" }, query);
 
@@ -283,14 +283,14 @@ void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& p
 
 void PFSDPBase::request_handle_udp(const std::string& packet_type)
 {
-  param_map_type query = { KV("address", info_->endpoint), KV("port", info_->port) };
+  param_vector_type query = { KV("address", info_->endpoint), KV("port", info_->port) };
   if (!packet_type.empty())
   {
-    query["packet_type"] = packet_type;
+    query.push_back(KV("packet_type", packet_type));
   }
   else
   {
-    query["packet_type"] = config_->packet_type;
+    query.push_back(KV("packet_type", config_->packet_type));
   }
   auto resp = get_request("request_handle_udp", { "handle", "port" }, query);
   info_->handle = resp["handle"];
@@ -312,13 +312,13 @@ void PFSDPBase::get_scanoutput_config(const std::string& handle)
 
 bool PFSDPBase::set_scanoutput_config(const std::string& handle, const ScanConfig& config)
 {
-  param_map_type query = { KV("handle", handle),
-                           KV("start_angle", config.start_angle),
-                           KV("packet_type", config.packet_type),
-                           KV("max_num_points_scan", config.max_num_points_scan),
-                           KV("watchdogtimeout", config.watchdogtimeout),
-                           KV("skip_scans", config.skip_scans),
-                           KV("watchdog", config.watchdog ? "on" : "off") };
+  param_vector_type query = { KV("handle", handle),
+                              KV("start_angle", config.start_angle),
+                              KV("packet_type", config.packet_type),
+                              KV("max_num_points_scan", config.max_num_points_scan),
+                              KV("watchdogtimeout", config.watchdogtimeout),
+                              KV("skip_scans", config.skip_scans),
+                              KV("watchdog", config.watchdog ? "on" : "off") };
   auto resp = get_request("set_scanoutput_config", { "" }, query);
 
   // update global config_
@@ -329,13 +329,13 @@ bool PFSDPBase::set_scanoutput_config(const std::string& handle, const ScanConfi
 
 bool PFSDPBase::update_scanoutput_config()
 {
-  param_map_type query = { KV("handle", info_->handle),
-                           KV("start_angle", config_->start_angle),
-                           KV("packet_type", config_->packet_type),
-                           KV("max_num_points_scan", config_->max_num_points_scan),
-                           KV("watchdogtimeout", config_->watchdogtimeout),
-                           KV("skip_scans", config_->skip_scans),
-                           KV("watchdog", config_->watchdog ? "on" : "off") };
+  param_vector_type query = { KV("handle", info_->handle),
+                              KV("start_angle", config_->start_angle),
+                              KV("packet_type", config_->packet_type),
+                              KV("max_num_points_scan", config_->max_num_points_scan),
+                              KV("watchdogtimeout", config_->watchdogtimeout),
+                              KV("skip_scans", config_->skip_scans),
+                              KV("watchdog", config_->watchdog ? "on" : "off") };
   auto resp = get_request("set_scanoutput_config", { "" }, query);
 
   // recalculate scan params


### PR DESCRIPTION
This branch shows how to ensure the order of arguments when making PFSDP requests to the sensor. Order is important at least  when making requests related to scan output (e.g. `release_handle`) where the `handle` must be the first argument.

Note these changes may collide with changes in other pending requests like for `fix/no-device-family`. I can soon update the branches after you pull the others.