### PR TITLE
Fixes memory misalignment on ARM based platforms

### DIFF
--- a/src/pf_driver/include/pf_driver/pf/scan_parameters.h
+++ b/src/pf_driver/include/pf_driver/pf/scan_parameters.h
@@ -2,7 +2,6 @@
 
 #include "pf_driver/pf/timesync.h"
 
-#pragma pack(push, sp, 1)
 struct ScanParameters
 {
   double radial_range_min = 0.0;
@@ -30,4 +29,3 @@ struct ScanParameters
   //   std::cout << std::endl;
   // }
 };
-#pragma pack(pop, sp)


### PR DESCRIPTION
When using `pf_driver` on a Raspberry Pi5, which is ARM based, I was having memory missalignment issues when the thread lock was being called on the _access mutex in the `timesync.cpp`.

After some investigation, I came across the `scan_parameters.h` to which `#pragma pack()` was used. After removing this, it works as expected.

Attached is a stack trace produced by backward-ros.
[pf_driver_stack_trace.txt](https://github.com/user-attachments/files/22491163/pf_driver_stack_trace.txt)
