### PR TITLE
Deprecated/ament target dependencies

### DIFF
--- a/src/pf_description/CMakeLists.txt
+++ b/src/pf_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.20)
 project(pf_description)
 
 find_package(ament_cmake REQUIRED)

--- a/src/pf_driver/CMakeLists.txt
+++ b/src/pf_driver/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(ament_index_cpp REQUIRED)
 find_package(pf_interfaces)
 find_package(laser_geometry REQUIRED)
 find_package(pcl_conversions REQUIRED)
-find_package(pcl_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -66,15 +65,12 @@ target_link_libraries(ros_main
   curl
   jsoncpp
   yaml-cpp
-)
-
-ament_target_dependencies(ros_main
-  rclcpp
-  pf_interfaces
-  laser_geometry
-  tf2_ros
-  pcl_ros
-  pf_interfaces
+  ${pf_interfaces_TARGETS}
+  laser_geometry::laser_geometry
+  pcl_conversions::pcl_conversions
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+  tf2_ros::tf2_ros
 )
 
 #roslint_cpp(src/ros/ros_main.cpp
@@ -108,13 +104,12 @@ if (BUILD_TESTING)
     curl
     jsoncpp
     yaml-cpp
-  )
-  ament_target_dependencies(${PROJECT_NAME}_test
-    ${THIS_PACKAGE_INCLUDE_DEPENDS}
-    laser_geometry
-    pcl_ros
-    pf_interfaces
-    rclcpp
+    ${pf_interfaces_TARGETS}
+    laser_geometry::laser_geometry
+    pcl_conversions::pcl_conversions
+    rclcpp::rclcpp
+    ${sensor_msgs_TARGETS}
+    tf2_ros::tf2_ros
   )
 endif()
 

--- a/src/pf_driver/CMakeLists.txt
+++ b/src/pf_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.20)
 project(pf_driver)
 
 set(CMAKE_POLICY_DEFAULT_CMP0144 OLD)

--- a/src/pf_driver/CMakeLists.txt
+++ b/src/pf_driver/CMakeLists.txt
@@ -67,17 +67,17 @@ target_link_libraries(ros_main
   yaml-cpp
   ${pf_interfaces_TARGETS}
   laser_geometry::laser_geometry
-  pcl_conversions::pcl_conversions
   rclcpp::rclcpp
   ${sensor_msgs_TARGETS}
   tf2_ros::tf2_ros
 )
-
-#roslint_cpp(src/ros/ros_main.cpp
-#            src/ros/scan_publisher.cpp
-#            src/pf/pf_interface.cpp
-#            src/pf/pf_packet.cpp
-#            src/communication.cpp)
+if (TARGET pcl_conversions::pcl_conversions)
+  target_link_libraries(ros_main pcl_conversions::pcl_conversions)
+else()
+  # Backward compatibility with Humble
+  target_link_libraries(ros_main ${pcl_conversions_LIBRARIES})
+  target_include_directories(ros_main PRIVATE ${pcl_conversions_INCLUDE_DIRS})
+endif()
 
 if (BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
@@ -99,17 +99,10 @@ if (BUILD_TESTING)
     $<INSTALL_INTERFACE:include>
   )
   target_link_libraries(${PROJECT_NAME}_test
-    ament_index_cpp::ament_index_cpp
-    curlpp
-    curl
-    jsoncpp
-    yaml-cpp
-    ${pf_interfaces_TARGETS}
-    laser_geometry::laser_geometry
-    pcl_conversions::pcl_conversions
-    rclcpp::rclcpp
-    ${sensor_msgs_TARGETS}
-    tf2_ros::tf2_ros
+    $<TARGET_PROPERTY:ros_main,LINK_LIBRARIES>
+  )
+  target_include_directories(${PROJECT_NAME}_test PRIVATE
+    $<TARGET_PROPERTY:ros_main,INCLUDE_DIRECTORIES>
   )
 endif()
 

--- a/src/pf_driver/package.xml
+++ b/src/pf_driver/package.xml
@@ -10,19 +10,19 @@
   <license>Apache2.0</license>
   <url type="website">https://github.com/PepperlFuchs/pf_lidar_ros_driver</url>
 
+  <build_depend>libjsoncpp-dev</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
+  <exec_depend>libjsoncpp</exec_depend>
   <exec_depend>libpcl-all</exec_depend>
   <exec_depend>pf_description</exec_depend>
-  <depend>pf_interfaces</depend>
   <depend>curlpp-dev</depend>
   <depend>laser_geometry</depend>
-  <depend>libjsoncpp-dev</depend>
   <depend>pcl_conversions</depend>
-  <depend>pcl_ros</depend>
+  <depend>pf_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/src/pf_interfaces/CMakeLists.txt
+++ b/src/pf_interfaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(pf_interfaces)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
This is required for ROS2 Lyrical.
And fully backwards compatible with existing ROS2 versions.

Deprecation message:

```
    Starting >>> pf_driver
    [Processing: pf_driver]
    --- stderr: pf_driver
    CMake Deprecation Warning at /opt/ros/kilted/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:87 (message):
      ament_target_dependencies() is deprecated.  Use target_link_libraries()
      with modern CMake targets instead.  Try replacing this call with:
    
        target_link_libraries(ros_main PUBLIC
    
          laser_geometry::laser_geometry
          pcl_ros::bag_to_pcd_lib
          pcl_ros::combined_pointcloud_to_pcd_lib
          pcl_ros::pcd_to_pointcloud_lib
          pcl_ros::pcl_ros_filter
          pcl_ros::pcl_ros_filters
          pcl_ros::pcl_ros_tf
          pcl_ros::pointcloud_to_pcd_lib
          rclcpp::rclcpp
          tf2_ros::static_transform_broadcaster_node
          tf2_ros::tf2_ros
        )
    
    Call Stack (most recent call first):
      CMakeLists.txt:71 (ament_target_dependencies)
    
    CMake Deprecation Warning at /opt/ros/kilted/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:87 (message):
      ament_target_dependencies() is deprecated.  Use target_link_libraries()
      with modern CMake targets instead.  Try replacing this call with:
    
        target_link_libraries(pf_driver_test PUBLIC
    
          laser_geometry::laser_geometry
          pcl_ros::bag_to_pcd_lib
          pcl_ros::combined_pointcloud_to_pcd_lib
          pcl_ros::pcd_to_pointcloud_lib
          pcl_ros::pcl_ros_filter
          pcl_ros::pcl_ros_filters
          pcl_ros::pcl_ros_tf
          pcl_ros::pointcloud_to_pcd_lib
          rclcpp::rclcpp
        )
    
    Call Stack (most recent call first):
      CMakeLists.txt:112 (ament_target_dependencies)
```