### PR TITLE
Implement handling of dropped and out-of-order udp packets

### DIFF
--- a/src/pf_driver/include/pf_driver/ros/pf_data_publisher.h
+++ b/src/pf_driver/include/pf_driver/ros/pf_data_publisher.h
@@ -26,6 +26,8 @@ public:
 protected:
   std::string frame_id_;
   uint16_t scan_number_ = 0;
+  uint16_t count_points_current_scan_ = 0;
+
   sensor_msgs::msg::LaserScan::SharedPtr msg_ = nullptr;
   std::mutex q_mutex_;
 

--- a/src/pf_driver/src/ros/pf_data_publisher.cpp
+++ b/src/pf_driver/src/ros/pf_data_publisher.cpp
@@ -82,6 +82,9 @@ void PFDataPublisher::update_timesync(T& packet)
 template <typename T>
 void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_inclination)
 {
+  const uint16_t packet_scan_number = packet.header.header.scan_number;
+  const uint16_t packet_number = packet.header.header.packet_number;
+
   if ((packet.header.status_flags & ((1u << 1) | (1 << 3))) != 0)
   {
     /* Information in packet is inconsistent due to new settings (1<<1) or while rotation is unstable (1<<3)
@@ -98,11 +101,17 @@ void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_incl
     params_->passive_timesync.reset(0.0);
   }
 
-  if ((msg_ != nullptr) && (packet.header.header.scan_number == scan_number_))
+  // drop packets that belong to last scan
+  // in case of out-of-order packets
+  if (packet_scan_number == scan_number_ - 1)
+  {
+    return;
+  }
+
+  if ((msg_ != nullptr) && (packet_scan_number == scan_number_))
   {
     /* msg_ already initialized and packet belongs to same scan, ie. is not first packet:
         No need to update msg_.header details. Just update passive timesync from packet. */
-
     update_timesync(packet);
   }
   else
@@ -110,19 +119,21 @@ void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_incl
     /* The incoming packet belongs to another scan than we have been recording until now
         (or, if !msg, it is the very first packet ever since we started receiving) */
 
-    /* TBD: Check if msg already has some data and handle_scan even if it's incomplete? */
-    //  handle_scan(msg_, layer_idx, layer_inclination, params_->apply_correction);
-
-    if (packet.header.header.packet_number != 1)
+    // if there is a pending message, send it out before starting to record the new scan
+    if (msg_ != nullptr)
     {
-      /* TBD: Discard whole scan if any packet is missing? */
-      // return;
+      // Start of a new scan, but data of old scan is available
+      // send out the old scan
+      handle_scan(msg_, layer_idx, layer_inclination, params_->apply_correction);
+      // the message was sent out, so we can release it here
+      msg_.reset();
     }
 
     msg_.reset(new sensor_msgs::msg::LaserScan());
+    count_points_current_scan_ = 0;
 
     msg_->header.frame_id.assign(frame_id_);
-    scan_number_ = packet.header.header.scan_number;
+    scan_number_ = packet_scan_number;
 
     const auto scan_time = rclcpp::Duration(0, 1000000ul * (1000000ul / packet.header.scan_frequency));
     msg_->scan_time = static_cast<float>(scan_time.seconds());
@@ -133,9 +144,9 @@ void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_incl
       /* Assuming that angle_min always means *first* angle (which may be numerically
        * greater than angle_max in case of negative angular_increment during CW rotation) */
 
-      msg_->angle_min = ((double)packet.header.first_angle) * (M_PI / 1800000.0);
+      msg_->angle_min = static_cast<double>(config_->start_angle) * (M_PI / 1800000.0);
       msg_->angle_max = msg_->angle_min +
-                        ((double)packet.header.num_points_scan * packet.header.angular_increment) * (M_PI / 1800000.0);
+                        static_cast<double>(packet.header.num_points_scan * packet.header.angular_increment) * (M_PI / 1800000.0);
 
       if (std::is_same<T, PFR2300Packet_C1>::value)  // packet interpretation specific to R2300 output
       {
@@ -250,8 +261,13 @@ void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_incl
     msg_->ranges[idx + i] = std::move(data);
   }
 
-  if (packet.header.num_points_scan == (idx + packet.header.num_points_packet))
+  count_points_current_scan_ += packet.header.num_points_packet;
+
+  // send out the scan if we have received all points for the scan
+  if (packet.header.num_points_scan == count_points_current_scan_)
   {
     handle_scan(msg_, layer_idx, layer_inclination, params_->apply_correction);
+    // the message was sent out, so we can release it here
+    msg_.reset();
   }
 }

--- a/src/pf_driver/src/ros/pf_data_publisher.cpp
+++ b/src/pf_driver/src/ros/pf_data_publisher.cpp
@@ -119,21 +119,30 @@ void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_incl
     /* The incoming packet belongs to another scan than we have been recording until now
         (or, if !msg, it is the very first packet ever since we started receiving) */
 
-    // if there is a pending message, send it out before starting to record the new scan
+    // if there is a pending message, packets were dropped or came out-of-order
+    // => Drop current message and start a new one
     if (msg_ != nullptr)
     {
-      // Start of a new scan, but data of old scan is available
-      // send out the old scan
-      handle_scan(msg_, layer_idx, layer_inclination, params_->apply_correction);
-      // the message was sent out, so we can release it here
+      RCLCPP_WARN(rclcpp::get_logger("pf_data_publisher"), "Dropping incomplete scan %d.", scan_number_);
+      // drop message by releasing it
       msg_.reset();
     }
 
-    msg_.reset(new sensor_msgs::msg::LaserScan());
+    // create new scan message and initialize header details from packet
+    msg_ = std::make_shared<sensor_msgs::msg::LaserScan>();
+    msg_->ranges.resize(packet.header.num_points_scan);
+    msg_->intensities.resize(packet.amplitude.empty() ? 0 : packet.header.num_points_scan);
     count_points_current_scan_ = 0;
-
     msg_->header.frame_id.assign(frame_id_);
     scan_number_ = packet_scan_number;
+
+    // We will only update the header details for the first packet of the scan
+    if (packet_number != 1)
+    {
+      // Quiet return; A warning message will be sent out when the next scan starts and 
+      // the incomplete scan message is discarded. This avoids flooding the log with warnings.
+      return;
+    }
 
     const auto scan_time = rclcpp::Duration(0, 1000000ul * (1000000ul / packet.header.scan_frequency));
     msg_->scan_time = static_cast<float>(scan_time.seconds());
@@ -144,7 +153,7 @@ void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_incl
       /* Assuming that angle_min always means *first* angle (which may be numerically
        * greater than angle_max in case of negative angular_increment during CW rotation) */
 
-      msg_->angle_min = static_cast<double>(config_->start_angle) * (M_PI / 1800000.0);
+      msg_->angle_min = static_cast<double>(packet.header.first_angle) * (M_PI / 1800000.0);
       msg_->angle_max = msg_->angle_min +
                         static_cast<double>(packet.header.num_points_scan * packet.header.angular_increment) * (M_PI / 1800000.0);
 
@@ -210,11 +219,6 @@ void PFDataPublisher::to_msg_queue(T& packet, uint16_t layer_idx, int layer_incl
     }
     msg_->header.stamp = first_acquired_point_stamp;
 
-    msg_->ranges.resize(packet.header.num_points_scan);
-    msg_->intensities.resize(packet.amplitude.empty() ? 0 : packet.header.num_points_scan);
-
-    /* TBD: Preload ranges and intensities with NaN? */
-    // msg_->ranges.assign(packet.header.num_points_scan, vector<float>(size, std::numeric_limits<float>::quiet_NaN()));
   }
 
   int idx = packet.header.first_index;


### PR DESCRIPTION
In case of out-of-order or dropped udp packets, the old implementation of pf_data_publisher.cpp calculated the start angle of the scan incorrectly.

The new implementation improves the following things:
- start angle is taken from the configuration
- the data of a missing udp packet is left out
- the data of an out-of-order packet is used, if the message for the respective scan has not been sent yet
- if a packet of a new scan is received, the currently recorded message is sent out, even if it is incomplete
- a message is sent out immediately if all scan points have been received