### PR TITLE
Update supported ROS2 distributions and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.json
 *.pyc
 *.orig
+build/
+install/
+log/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OMDxxx-R2000 Hardware & Firmware >= 1.50 (No support of OBDxxx-R2000 devices)
 OMDxxx-R2300 Hardware >= 0.95, Firmware >= 0.97
 
 **Required platform:**  
-Ubuntu-20.04/ROS-Foxy OR Ubuntu-20.04/ROS-Galactic OR Ubuntu-22.04/ROS-Humble OR Ubuntu-24.04/ROS-Jazzy
+Ubuntu-22.04/ROS-Humble OR Ubuntu-24.04/ROS-Jazzy OR Ubuntu-24.04/ROS-Kilted
 
 Note: The ROS1 driver is available here: https://github.com/PepperlFuchs/pf_lidar_ros_driver
   


### PR DESCRIPTION
Update the supported ROS2 distributions to the currently supported ROS2 versions.

Add the folders build/, install/ and log/ to .gitignore. They are created during the build process.